### PR TITLE
Feature/fix stats after multiplayer coop update

### DIFF
--- a/extensions/ui/hud/more_ui.gd
+++ b/extensions/ui/hud/more_ui.gd
@@ -149,14 +149,14 @@ func _ready()->void:
 	_more_ui_timer.set_one_shot(false) # Make sure it loops
 	_more_ui_timer.set_wait_time(0.5)
 	_more_ui_timer.start()
+		
+	# Todo: Build in support for games with multiple players?
+	var player_index = 0; # First player
 	
 	if (_whats_new_mode_enabled):
 		_toggle_control_visbility(false)	
 	if (_whats_new_mode_enabled || _wave_increase_enabled):
 		var t = Timer.new()
-		
-		# Todo: Build in support for games with multiple players?
-		var player_index = 0; # First player
 		
 		t.set_wait_time(.2)
 		t.set_one_shot(true)
@@ -184,8 +184,12 @@ func _ready()->void:
 	_update_stats_ui()
 	
 	var possible_chances = ceil(wave_timer.wait_time / 10) - 1
-	var min_nb = (1 + RunData.effects["trees"])
-	var max_nb = (2 + RunData.effects["trees"])
+	
+	var player_effect_trees =  RunData.get_player_effect('trees', player_index);
+
+	var min_nb = (1 + player_effect_trees)
+	var max_nb = (2 + player_effect_trees)
+
 	for i in possible_chances:
 		var min_total_chance:float = min_nb * 0.33
 		var max_total_chance:float = max_nb * 0.33

--- a/extensions/ui/hud/more_ui.gd
+++ b/extensions/ui/hud/more_ui.gd
@@ -154,27 +154,31 @@ func _ready()->void:
 		_toggle_control_visbility(false)	
 	if (_whats_new_mode_enabled || _wave_increase_enabled):
 		var t = Timer.new()
+		
+		# Todo: Build in support for games with multiple players?
+		var player_index = 0; # First player
+		
 		t.set_wait_time(.2)
 		t.set_one_shot(true)
 		self.add_child(t)
 		t.start()
 		yield(t, "timeout")
-		inital_max_hp = floor(Utils.get_stat('stat_max_hp'))
-		inital_hp_regen = floor(Utils.get_stat('stat_hp_regeneration'))
-		inital_lifesteal = floor(Utils.get_stat('stat_lifesteal'))
-		inital_damage = floor(Utils.get_stat('stat_percent_damage'))
-		inital_melee_damage = floor(Utils.get_stat('stat_melee_damage'))
-		inital_ranged_damage = floor(Utils.get_stat('stat_ranged_damage'))
-		inital_elemental_damage = floor(Utils.get_stat('stat_elemental_damage'))
-		inital_attack_speed = floor(Utils.get_stat('stat_attack_speed'))
-		inital_crit_chance = floor(Utils.get_stat('stat_crit_chance'))
-		inital_engineering = floor(Utils.get_stat('stat_engineering'))
-		inital_range = floor(Utils.get_stat('stat_range'))
-		inital_armor = floor(Utils.get_stat('stat_armor'))
-		inital_dodge = floor(Utils.get_stat('stat_dodge'))
-		inital_speed = floor(Utils.get_stat('stat_speed'))
-		inital_luck = floor(Utils.get_stat('stat_luck'))
-		inital_harvesting = floor(Utils.get_stat('stat_harvesting'))
+		inital_max_hp = floor(Utils.get_stat('stat_max_hp', player_index))
+		inital_hp_regen = floor(Utils.get_stat('stat_hp_regeneration', player_index))
+		inital_lifesteal = floor(Utils.get_stat('stat_lifesteal', player_index))
+		inital_damage = floor(Utils.get_stat('stat_percent_damage', player_index))
+		inital_melee_damage = floor(Utils.get_stat('stat_melee_damage', player_index))
+		inital_ranged_damage = floor(Utils.get_stat('stat_ranged_damage', player_index))
+		inital_elemental_damage = floor(Utils.get_stat('stat_elemental_damage', player_index))
+		inital_attack_speed = floor(Utils.get_stat('stat_attack_speed', player_index))
+		inital_crit_chance = floor(Utils.get_stat('stat_crit_chance', player_index))
+		inital_engineering = floor(Utils.get_stat('stat_engineering', player_index))
+		inital_range = floor(Utils.get_stat('stat_range', player_index))
+		inital_armor = floor(Utils.get_stat('stat_armor', player_index))
+		inital_dodge = floor(Utils.get_stat('stat_dodge', player_index))
+		inital_speed = floor(Utils.get_stat('stat_speed', player_index))
+		inital_luck = floor(Utils.get_stat('stat_luck', player_index))
+		inital_harvesting = floor(Utils.get_stat('stat_harvesting', player_index))
 		inital_trees = 0
 	
 	_update_stats_ui()
@@ -190,6 +194,8 @@ func _ready()->void:
 	
 	
 func _update_stats_ui():
+	# Todo: Build in support for games with multiple players?
+	var player_index = 0; # First player
 	
 	if wave_timer != null and is_instance_valid(wave_timer) and not is_run_lost:
 		var time = ceil(wave_timer.time_left)
@@ -199,23 +205,23 @@ func _update_stats_ui():
 			more_ui_container.visible = false
 			return
 	
-	_update_single_field(hp_regen_field, 'stat_hp_regeneration', inital_hp_regen, hp_regen_field_control)
-	_update_single_field(lifesteal_field, 'stat_lifesteal', inital_lifesteal, lifesteal_field_control)
-	_update_single_field(damage_field,'stat_percent_damage', inital_damage, damage_field_control)
-	_update_single_field(melee_damage_field, 'stat_melee_damage', inital_melee_damage, melee_damage_field_control)
-	_update_single_field(ranged_damage_field, 'stat_ranged_damage', inital_ranged_damage, ranged_damage_field_control)
-	_update_single_field(elemental_damage_field, 'stat_elemental_damage', inital_elemental_damage, elemental_damage_field_control)
-	_update_single_field(attack_speed_field, 'stat_attack_speed', inital_attack_speed, attack_speed_field_control)
-	_update_single_field(crit_chance_field, 'stat_crit_chance', inital_crit_chance, crit_chance_field_control)
-	_update_single_field(engineering_field, 'stat_engineering', inital_engineering, engineering_field_control)
-	_update_single_field(range_field, 'stat_range', inital_range, range_field_control)
-	_update_single_field(armor_field, 'stat_armor', inital_armor, armor_field_control)
-	_update_single_field(luck_field, 'stat_luck', inital_luck, luck_field_control)
-	_update_single_field(harvesting_field, 'stat_harvesting', inital_harvesting, harvesting_field_control)
+	_update_single_field(hp_regen_field, 'stat_hp_regeneration', inital_hp_regen, hp_regen_field_control, player_index)
+	_update_single_field(lifesteal_field, 'stat_lifesteal', inital_lifesteal, lifesteal_field_control, player_index)
+	_update_single_field(damage_field,'stat_percent_damage', inital_damage, damage_field_control, player_index)
+	_update_single_field(melee_damage_field, 'stat_melee_damage', inital_melee_damage, melee_damage_field_control, player_index)
+	_update_single_field(ranged_damage_field, 'stat_ranged_damage', inital_ranged_damage, ranged_damage_field_control, player_index)
+	_update_single_field(elemental_damage_field, 'stat_elemental_damage', inital_elemental_damage, elemental_damage_field_control, player_index)
+	_update_single_field(attack_speed_field, 'stat_attack_speed', inital_attack_speed, attack_speed_field_control, player_index)
+	_update_single_field(crit_chance_field, 'stat_crit_chance', inital_crit_chance, crit_chance_field_control, player_index)
+	_update_single_field(engineering_field, 'stat_engineering', inital_engineering, engineering_field_control, player_index)
+	_update_single_field(range_field, 'stat_range', inital_range, range_field_control, player_index)
+	_update_single_field(armor_field, 'stat_armor', inital_armor, armor_field_control, player_index)
+	_update_single_field(luck_field, 'stat_luck', inital_luck, luck_field_control, player_index)
+	_update_single_field(harvesting_field, 'stat_harvesting', inital_harvesting, harvesting_field_control, player_index)
 	
 	if dodge_field != null:
-		var dodgeValue = floor(Utils.get_stat('stat_dodge'))
-		var maxDodge = Utils.get_stat('dodge_cap') - 120
+		var dodgeValue = floor(Utils.get_stat('stat_dodge', player_index))
+		var maxDodge = Utils.get_stat('dodge_cap', player_index) - 120
 		var dodgeString = str(dodgeValue);
 		if (dodgeValue >= maxDodge):
 			dodgeString += ' | ' + str(maxDodge)
@@ -232,9 +238,9 @@ func _update_stats_ui():
 		if (_whats_new_mode_enabled && dodgeValue != inital_dodge):
 			dodge_field_control.visible = true
 	if max_hp_field != null:
-		var maxHPValue = floor(Utils.get_stat('stat_max_hp'))
+		var maxHPValue = floor(Utils.get_stat('stat_max_hp', player_index))
 		var maxHPString = str(maxHPValue);
-		var maxHPCap = Utils.get_stat('hp_cap');
+		var maxHPCap = Utils.get_stat('hp_cap', player_index);
 		if (maxHPValue >= maxHPCap && maxHPCap != 999999):
 			maxHPString += ' | ' + str(maxHPCap)
 			
@@ -251,8 +257,8 @@ func _update_stats_ui():
 			max_hp_field_control.visible = true
 			
 	if speed_field != null:
-		var speedValue = floor(Utils.get_stat('stat_speed'))
-		var maxSpeed = Utils.get_stat('speed_cap')
+		var speedValue = floor(Utils.get_stat('stat_speed', player_index))
+		var maxSpeed = Utils.get_stat('speed_cap', player_index)
 		var speedString = str(speedValue);
 		if (speedValue >= maxSpeed):
 			speedString += ' | ' + str(maxSpeed)
@@ -278,9 +284,9 @@ func _update_stats_ui():
 				trees_field_control.visible = true
 		
 
-func _update_single_field(field,stat_name,initial_value,control):
+func _update_single_field(field, stat_name, initial_value, control, player_index):
 	if field != null:
-		var value = floor(Utils.get_stat(stat_name))
+		var value = floor(Utils.get_stat(stat_name, player_index))
 		var output = str(value)
 		var change = value - initial_value;
 		if (_wave_increase_enabled and change != 0):


### PR DESCRIPTION
In the update of 25 october 2024 they added support for local co-op.
Because of this update an extra argument was needed (player_index) to retrieve player stats.

I have updated this mod to provide the missing argument with the index of the first player (no multiplayer support yet!)

![image](https://github.com/user-attachments/assets/57f02e75-6292-4341-8a0a-7728d9c944b7)
